### PR TITLE
Prevent output pollution in projects which link to the library

### DIFF
--- a/library/include/ProceduralMultiShape.h
+++ b/library/include/ProceduralMultiShape.h
@@ -92,7 +92,7 @@ public:
 	/// Returns the number of shapes in that MultiShape
 	unsigned int getShapeCount() const
 	{
-		return mShapes.size();
+		return (unsigned int)mShapes.size();
 	}
 
 	/// Append every shape of an other multishape to the current multiShape

--- a/library/include/ProceduralPath.h
+++ b/library/include/ProceduralPath.h
@@ -160,8 +160,8 @@ public:
 	const Ogre::Vector3& getPoint(int i) const
 	{
 		if (mClosed)
-			return mPoints[Utils::modulo(i,mPoints.size())];
-		return mPoints[Utils::cap(i,0,mPoints.size()-1)];
+			return mPoints[Utils::modulo(i,(int)mPoints.size())];
+		return mPoints[Utils::cap(i,0,(int)mPoints.size()-1)];
 	}
 
 	/** Gets the number of segments in the path
@@ -169,7 +169,7 @@ public:
 	 */
 	int getSegCount() const
 	{
-		return (mPoints.size()-1) + (mClosed?1:0);
+		return (int)(mPoints.size()-1) + (mClosed?1:0);
 	}
 
 	/**
@@ -391,7 +391,7 @@ public:
 
 	unsigned int getPathCount() const
 	{
-		return mPaths.size();
+		return (unsigned int)mPaths.size();
 	}
 
 	Path getPath(unsigned int i) const

--- a/library/include/ProceduralPathGenerators.h
+++ b/library/include/ProceduralPathGenerators.h
@@ -86,8 +86,8 @@ public:
 	inline const Ogre::Vector3& safeGetPoint(unsigned int i) const
 	{
 		if (mClosed)
-			return mPoints[Utils::modulo(i,mPoints.size())];
-		return mPoints[Utils::cap(i,0,mPoints.size()-1)];
+			return mPoints[Utils::modulo(i,(int)mPoints.size())];
+		return mPoints[Utils::cap(i,0,(int)mPoints.size()-1)];
 	}
 
 	/// Gets the number of control points
@@ -149,8 +149,8 @@ public:
 	inline const ControlPoint& safeGetPoint(unsigned int i) const
 	{
 		if (mClosed)
-			return mPoints[Utils::modulo(i,mPoints.size())];
-		return mPoints[Utils::cap(i,0,mPoints.size()-1)];
+			return mPoints[Utils::modulo(i,(int)mPoints.size())];
+		return mPoints[Utils::cap(i,0,(int)mPoints.size()-1)];
 	}
 
 	/// Gets the number of control points
@@ -259,8 +259,8 @@ public:
 	inline const Ogre::Vector3& safeGetPoint(unsigned int i) const
 	{
 		if (mClosed)
-			return mPoints[Utils::modulo(i,mPoints.size())];
-		return mPoints[Utils::cap(i,0,mPoints.size()-1)];
+			return mPoints[Utils::modulo(i,(int)mPoints.size())];
+		return mPoints[Utils::cap(i,0,(int)mPoints.size()-1)];
 	}
 
 	/// Gets the number of control points
@@ -317,8 +317,8 @@ public:
 	inline const Ogre::Vector3& safeGetPoint(unsigned int i) const
 	{
 		if (mClosed)
-			return mPoints[Utils::modulo(i,mPoints.size())];
-		return mPoints[Utils::cap(i,0,mPoints.size()-1)];
+			return mPoints[Utils::modulo(i,(int)mPoints.size())];
+		return mPoints[Utils::cap(i,0,(int)mPoints.size()-1)];
 	}
 
 	/// Gets the number of control points

--- a/library/include/ProceduralShape.h
+++ b/library/include/ProceduralShape.h
@@ -205,8 +205,8 @@ public:
 	inline unsigned int getBoundedIndex(int i) const
 	{
 		if (mClosed)
-			return Utils::modulo(i,mPoints.size());
-		return Utils::cap(i,0,mPoints.size()-1);
+			return Utils::modulo(i,(int)mPoints.size());
+		return Utils::cap(i,0,(int)mPoints.size()-1);
 	}
 
 	/// Gets number of points in current point list

--- a/library/include/ProceduralShapeGenerators.h
+++ b/library/include/ProceduralShapeGenerators.h
@@ -88,8 +88,8 @@ public:
 	inline const ControlPoint& safeGetPoint(unsigned int i) const
 	{
 		if (mClosed)
-			return mPoints[Utils::modulo(i,mPoints.size())];
-		return mPoints[Utils::cap(i,0,mPoints.size()-1)];
+			return mPoints[Utils::modulo(i,(int)mPoints.size())];
+		return mPoints[Utils::cap(i,0,(int)mPoints.size()-1)];
 	}
 
 	/// Gets the number of control points
@@ -132,8 +132,8 @@ public:
 	inline const Ogre::Vector2& safeGetPoint(unsigned int i) const
 	{
 		if (mClosed)
-			return mPoints[Utils::modulo(i,mPoints.size())];
-		return mPoints[Utils::cap(i,0,mPoints.size()-1)];
+			return mPoints[Utils::modulo(i,(int)mPoints.size())];
+		return mPoints[Utils::cap(i,0,(int)mPoints.size()-1)];
 	}
 
 	/// Gets the number of control points
@@ -180,8 +180,8 @@ public:
 	inline const ControlPoint& safeGetPoint(unsigned int i) const
 	{
 		if (mClosed)
-			return mPoints[Utils::modulo(i,mPoints.size())];
-		return mPoints[Utils::cap(i,0,mPoints.size()-1)];
+			return mPoints[Utils::modulo(i,(int)mPoints.size())];
+		return mPoints[Utils::cap(i,0,(int)mPoints.size()-1)];
 	}
 
 	/**
@@ -481,8 +481,8 @@ public:
 	inline const Ogre::Vector2& safeGetPoint(unsigned int i) const
 	{
 		if (mClosed)
-			return mPoints[Utils::modulo(i,mPoints.size())];
-		return mPoints[Utils::cap(i,0,mPoints.size()-1)];
+			return mPoints[Utils::modulo(i,(int)mPoints.size())];
+		return mPoints[Utils::cap(i,0,(int)mPoints.size()-1)];
 	}
 
 	/// Gets the number of control points
@@ -540,8 +540,8 @@ public:
 	inline const Ogre::Vector2& safeGetPoint(unsigned int i) const
 	{
 		if (mClosed)
-			return mPoints[Utils::modulo(i,mPoints.size())];
-		return mPoints[Utils::cap(i,0,mPoints.size()-1)];
+			return mPoints[Utils::modulo(i,(int)mPoints.size())];
+		return mPoints[Utils::cap(i,0,(int)mPoints.size()-1)];
 	}
 
 	/// Gets the number of control points

--- a/library/include/ProceduralTriangleBuffer.h
+++ b/library/include/ProceduralTriangleBuffer.h
@@ -86,16 +86,16 @@ public:
 		rebaseOffset();
 		Section section;
 		section.mSectionName = "";
-		section.mFirstIndex = mIndices.size();
-		section.mFirstVertex = mVertices.size();
+		section.mFirstIndex = (unsigned int)mIndices.size();
+		section.mFirstVertex = (unsigned int)mVertices.size();
 		section.buffer = this;
 		return section;
 	}
 
 	void endSection(Section& section)
 	{
-		section.mLastIndex = mIndices.size() - 1;
-		section.mLastVertex = mVertices.size() - 1;
+		section.mLastIndex = (unsigned int)mIndices.size() - 1;
+		section.mLastVertex = (unsigned int)mVertices.size() - 1;
 		if (section.mSectionName != "")
 			mSections[section.mSectionName] = section;		
 	}
@@ -104,9 +104,9 @@ public:
 	{
 		Section section;
 		section.mFirstIndex = 0;
-		section.mLastIndex = mIndices.size() - 1;
+		section.mLastIndex = (unsigned int)mIndices.size() - 1;
 		section.mFirstVertex = 0;
-		section.mLastVertex = mVertices.size() - 1;
+		section.mLastVertex = (unsigned int)mVertices.size() - 1;
 		section.mSectionName = "";
 		section.buffer = this;
 		return section;
@@ -141,7 +141,7 @@ public:
 	 */
 	void rebaseOffset()
 	{
-		globalOffset = mVertices.size();
+		globalOffset = (int)mVertices.size();
 	}
 
 	/**


### PR DESCRIPTION
Some header implemented methods still use the fundamental types instead of the more appropriate `std::size_t` type. This cause a lot of noise (due to compiler warnings) in buiding 64-bit projects. I'm not feeling such confident to replace all the fundamental types, but casting them should silence the compiler without breaking anything (which isn't already broken 😄).