### PR TITLE
bugfix: box generator no longer flips positive and negative x-axis planes 90 degrees on the x-axis.

### DIFF
--- a/library/src/ProceduralBoxGenerator.cpp
+++ b/library/src/ProceduralBoxGenerator.cpp
@@ -79,14 +79,14 @@ void BoxGenerator::addToTriangleBuffer(TriangleBuffer& buffer) const
 	buffer.endSection(section);
 
 	section = buffer.beginSection(TAG_NEGX);
-	pg.setNumSegX(mNumSegZ).setNumSegY(mNumSegY).setSizeX(mSizeZ).setSizeY(mSizeY)
+	pg.setNumSegX(mNumSegY).setNumSegY(mNumSegZ).setSizeX(mSizeY).setSizeY(mSizeZ)
 	.setNormal(Vector3::NEGATIVE_UNIT_X)
 	.setPosition(mScale*(mPosition+.5f*mSizeX*(mOrientation*Vector3::NEGATIVE_UNIT_X)))
 	.addToTriangleBuffer(buffer);
 	buffer.endSection(section);
 
 	section = buffer.beginSection(TAG_X);
-	pg.setNumSegX(mNumSegZ).setNumSegY(mNumSegY).setSizeX(mSizeZ).setSizeY(mSizeY)
+	pg.setNumSegX(mNumSegY).setNumSegY(mNumSegZ).setSizeX(mSizeY).setSizeY(mSizeZ)
 	.setNormal(Vector3::UNIT_X)
 	.setPosition(mScale*(mPosition+.5f*mSizeX*(mOrientation*Vector3::UNIT_X)))
 	.addToTriangleBuffer(buffer);


### PR DESCRIPTION
minimal reproduction of the bug:

// i want a box 1x1x2 along x,y,z world axes
auto mesh = Procedural::BoxGenerator (1,1,2,1,1,1).realizeMesh ("boxtest", "test_group");
auto* scene = Ogre::Root::getSingleton ().getSceneManagers ().begin ()->second;
auto node = scene->getRootSceneNode ()->createChildSceneNode ();
auto entity = scene->createEntity (mesh);
node->attachObject (entity);