### PR TITLE
Add support to choose mesh material during its creation

### DIFF
--- a/docs/manual/illustrations/src/Illustrations.cpp
+++ b/docs/manual/illustrations/src/Illustrations.cpp
@@ -83,7 +83,7 @@ void Illustrations::setup()
 
 	// Create main render to texture
 	mRttTexture = Ogre::TextureManager::getSingleton().createManual("RttTex", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
-	              Ogre::TEX_TYPE_2D, 256, 256, 0, Ogre::PF_R8G8B8, Ogre::TU_RENDERTARGET, 0, 0, 4);
+	              Ogre::TEX_TYPE_2D, 256, 256, 0, Ogre::PF_BYTE_RGBA, Ogre::TU_RENDERTARGET, 0, 0, 4);
 	mRenderTexture = mRttTexture->getBuffer()->getRenderTarget();
 #if OGRE_VERSION < ((2 << 16) | (0 << 8) | 0)
 	Ogre::Viewport* vp = mRenderTexture->addViewport(mCam);
@@ -156,20 +156,13 @@ void Illustrations::exportImage(std::string name, Procedural::TextureBufferPtr b
 		{
 			Ogre::ColourValue pixel = Ogre::ColourValue::White;
 			if (x >= border && x < (w - border) && y >= border && y < (h - border)) pixel = pImgData->getColourAt(x - border, y - border, 0);
-#if OGRE_ENDIAN == OGRE_ENDIAN_LITTLE
-			pixelBuffer[y * w * 4 + x * 4 + 3] = (Ogre::uchar)std::min<Ogre::Real>(std::max<Ogre::Real>(pixel.r * 255.0f, 0.0f), 255.0f);
-			pixelBuffer[y * w * 4 + x * 4 + 2] = (Ogre::uchar)std::min<Ogre::Real>(std::max<Ogre::Real>(pixel.g * 255.0f, 0.0f), 255.0f);
-			pixelBuffer[y * w * 4 + x * 4 + 1] = (Ogre::uchar)std::min<Ogre::Real>(std::max<Ogre::Real>(pixel.b * 255.0f, 0.0f), 255.0f);
-			pixelBuffer[y * w * 4 + x * 4 + 0] = (Ogre::uchar)std::min<Ogre::Real>(std::max<Ogre::Real>(pixel.a * 255.0f, 0.0f), 255.0f);
-#else
 			pixelBuffer[y * w * 4 + x * 4 + 0] = (Ogre::uchar)std::min<Ogre::Real>(std::max<Ogre::Real>(pixel.r * 255.0f, 0.0f), 255.0f);
 			pixelBuffer[y * w * 4 + x * 4 + 1] = (Ogre::uchar)std::min<Ogre::Real>(std::max<Ogre::Real>(pixel.g * 255.0f, 0.0f), 255.0f);
 			pixelBuffer[y * w * 4 + x * 4 + 2] = (Ogre::uchar)std::min<Ogre::Real>(std::max<Ogre::Real>(pixel.b * 255.0f, 0.0f), 255.0f);
 			pixelBuffer[y * w * 4 + x * 4 + 3] = (Ogre::uchar)std::min<Ogre::Real>(std::max<Ogre::Real>(pixel.a * 255.0f, 0.0f), 255.0f);
-#endif
 		}
 	}
-	image->loadDynamicImage(pixelBuffer, w, h, 1, PF_R8G8B8A8);
+	image->loadDynamicImage(pixelBuffer, w, h, 1, PF_BYTE_RGBA);
 	image->save(name + ".png");
 	delete image;
 	delete pixelBuffer;

--- a/library/include/ProceduralMultiShape.h
+++ b/library/include/ProceduralMultiShape.h
@@ -105,7 +105,7 @@ public:
 	}
 
 	/// Outputs the Multi Shape to a Mesh, mostly for visualisation or debugging purposes
-	Ogre::v1::MeshPtr realizeMesh(const std::string& name="");
+	Ogre::v1::MeshPtr realizeMesh(const std::string& name="", const std::string& materialName="BaseWhiteNoLighting");
 
 	/// Tells whether a point is located inside that multishape
 	/// It assumes that all of the shapes in that multishape are closed,

--- a/library/include/ProceduralPath.h
+++ b/library/include/ProceduralPath.h
@@ -238,7 +238,7 @@ public:
 	 * Outputs a mesh representing the path.
 	 * Mostly for debugging purposes
 	 */
-	Ogre::v1::MeshPtr realizeMesh(const std::string& name = "") const;
+	Ogre::v1::MeshPtr realizeMesh(const std::string& name = "", const std::string& materialName = "BaseWhiteNoLighting") const;
 
 	/// Creates a path with the keys of this path and extra keys coming from a track
 	Path mergeKeysWithTrack(const Track& track) const;

--- a/library/include/ProceduralShape.h
+++ b/library/include/ProceduralShape.h
@@ -321,7 +321,7 @@ public:
 	 * Outputs a mesh representing the shape.
 	 * Mostly for debugging purposes
 	 */
-	Ogre::v1::MeshPtr realizeMesh(const std::string& name="") const;
+	Ogre::v1::MeshPtr realizeMesh(const std::string& name="", const std::string& materialName="BaseWhiteNoLighting") const;
 
 	/**
 	 * Appends the shape vertices to a manual object being edited

--- a/library/include/ProceduralTextureBuffer.h
+++ b/library/include/ProceduralTextureBuffer.h
@@ -45,7 +45,6 @@ typedef TextureBuffer* TextureBufferPtr;
 /**
 \brief class to store image data while processing
 \details Create a TextureBuffer object and move it to all classes inherited from TextureProcessing
-\todo check byte order for image generation (OGRE_ENDIAN, OGRE_ENDIAN_LITTLE, OGRE_ENDIAN_BIG), see <a href="http://www.ogre3d.org/forums/viewtopic.php?f=2&t=72832" target="_blank">Ogre forum</a> for details.
 \todo Increase speed of reading and writeing pixel values.
 */
 class _ProceduralExport TextureBuffer

--- a/library/include/ProceduralTriangleBuffer.h
+++ b/library/include/ProceduralTriangleBuffer.h
@@ -148,7 +148,8 @@ public:
 	 * Builds an Ogre Mesh from this buffer.
 	 */
 	Ogre::v1::MeshPtr transformToMesh(const std::string& name,
-	                              const Ogre::String& group = "General") const;
+	                              const Ogre::String& group = "General",
+	                              const Ogre::String& materialName = "BaseWhiteNoLighting") const;
 
 	/** Adds a new vertex to the buffer */
 	inline TriangleBuffer& vertex(const Vertex& v)

--- a/library/src/ProceduralBoxGenerator.cpp
+++ b/library/src/ProceduralBoxGenerator.cpp
@@ -79,14 +79,14 @@ void BoxGenerator::addToTriangleBuffer(TriangleBuffer& buffer) const
 	buffer.endSection(section);
 
 	section = buffer.beginSection(TAG_NEGX);
-	pg.setNumSegX(mNumSegZ).setNumSegY(mNumSegY).setSizeX(mSizeZ).setSizeY(mSizeY)
+	pg.setNumSegX(mNumSegY).setNumSegY(mNumSegZ).setSizeX(mSizeY).setSizeY(mSizeZ)
 	.setNormal(Vector3::NEGATIVE_UNIT_X)
 	.setPosition(mScale*(mPosition+.5f*mSizeX*(mOrientation*Vector3::NEGATIVE_UNIT_X)))
 	.addToTriangleBuffer(buffer);
 	buffer.endSection(section);
 
 	section = buffer.beginSection(TAG_X);
-	pg.setNumSegX(mNumSegZ).setNumSegY(mNumSegY).setSizeX(mSizeZ).setSizeY(mSizeY)
+	pg.setNumSegX(mNumSegY).setNumSegY(mNumSegZ).setSizeX(mSizeY).setSizeY(mSizeZ)
 	.setNormal(Vector3::UNIT_X)
 	.setPosition(mScale*(mPosition+.5f*mSizeX*(mOrientation*Vector3::UNIT_X)))
 	.addToTriangleBuffer(buffer);

--- a/library/src/ProceduralMultiShape.cpp
+++ b/library/src/ProceduralMultiShape.cpp
@@ -36,7 +36,7 @@ namespace Procedural
 {
 //-----------------------------------------------------------------------
 
-v1::MeshPtr MultiShape::realizeMesh(const std::string& name)
+v1::MeshPtr MultiShape::realizeMesh(const std::string& name, const std::string& materialName)
 {
 	Ogre::SceneManager* smgr = Ogre::Root::getSingleton().getSceneManagerIterator().begin()->second;
 #if OGRE_VERSION < ((2 << 16) | (0 << 8) | 0)
@@ -48,7 +48,7 @@ v1::MeshPtr MultiShape::realizeMesh(const std::string& name)
 
 	for (std::vector<Shape>::iterator it = mShapes.begin(); it != mShapes.end(); ++it)
 	{
-		manual->begin("BaseWhiteNoLighting", OperationType::OT_LINE_STRIP);
+		manual->begin(materialName, OperationType::OT_LINE_STRIP);
 		it->_appendToManualObject(manual);
 		manual->end();
 	}

--- a/library/src/ProceduralPath.cpp
+++ b/library/src/ProceduralPath.cpp
@@ -73,11 +73,11 @@ Path Path::mergeKeysWithTrack(const Track& track) const
 	return outputPath;
 }
 
-Ogre::v1::MeshPtr Path::realizeMesh(const std::string& name) const
+Ogre::v1::MeshPtr Path::realizeMesh(const std::string& name, const std::string& materialName) const
 {
 	Ogre::SceneManager* smgr = Ogre::Root::getSingleton().getSceneManagerIterator().begin()->second;
 	Ogre::v1::ManualObject* manual = OGRE_NEW Ogre::v1::ManualObject(Ogre::Id::generateNewId<Ogre::v1::ManualObject>(), &smgr->_getEntityMemoryManager(Ogre::SCENE_DYNAMIC), smgr);
-	manual->begin("BaseWhiteNoLighting", Ogre::OperationType::OT_LINE_STRIP);
+	manual->begin(materialName, Ogre::OperationType::OT_LINE_STRIP);
 
 	for (std::vector<Ogre::Vector3>::const_iterator itPos = mPoints.begin(); itPos != mPoints.end(); itPos++)
 		manual->position(*itPos);

--- a/library/src/ProceduralShape.cpp
+++ b/library/src/ProceduralShape.cpp
@@ -440,11 +440,11 @@ bool Shape::isPointInside(const Vector2& point) const
 		return true;
 }
 //-----------------------------------------------------------------------
-v1::MeshPtr Shape::realizeMesh(const std::string& name) const
+v1::MeshPtr Shape::realizeMesh(const std::string& name, const std::string& materialName) const
 {
 	Ogre::SceneManager* smgr = Ogre::Root::getSingleton().getSceneManagerIterator().begin()->second;
 	v1::ManualObject* manual = OGRE_NEW v1::ManualObject(Id::generateNewId<v1::ManualObject>(), &smgr->_getEntityMemoryManager(SCENE_DYNAMIC), smgr);
-	manual->begin("BaseWhiteNoLighting", OperationType::OT_LINE_STRIP);
+	manual->begin(materialName, OperationType::OT_LINE_STRIP);
 
 	_appendToManualObject(manual);
 

--- a/library/src/ProceduralTextureBuffer.cpp
+++ b/library/src/ProceduralTextureBuffer.cpp
@@ -38,17 +38,10 @@ namespace Procedural
 
 using namespace Ogre;
 
-#if OGRE_ENDIAN == OGRE_ENDIAN_LITTLE
-#define PROCEDURAL_RED 3
-#define PROCEDURAL_GREEN 2
-#define PROCEDURAL_BLUE 1
-#define PROCEDURAL_ALPHA 0
-#else
 #define PROCEDURAL_RED 0
 #define PROCEDURAL_GREEN 1
 #define PROCEDURAL_BLUE 2
 #define PROCEDURAL_ALPHA 3
-#endif
 
 TextureBuffer::TextureBuffer(TextureBufferPtr tocopy)
 {
@@ -293,7 +286,7 @@ Ogre::TextureGpu* TextureBuffer::createTexture(Ogre::String name) const
 Ogre::Image* TextureBuffer::getImage() const
 {
 	Ogre::Image* image = new Ogre::Image();
-	image->loadDynamicImage(mPixels, mWidth, mHeight, 1, PF_R8G8B8A8);
+	image->loadDynamicImage(mPixels, mWidth, mHeight, 1, PF_BYTE_RGBA);
 	return image;
 }
 
@@ -313,7 +306,7 @@ Ogre::TexturePtr TextureBuffer::createTexture(Ogre::String name, Ogre::String gr
 	                               mWidth,
 	                               mHeight,
 	                               0,
-	                               PF_R8G8B8A8,
+	                               PF_BYTE_RGBA,
 	                               TU_DEFAULT);
 
 	Ogre::Image* image = getImage();

--- a/library/src/ProceduralTextureGenerator.cpp
+++ b/library/src/ProceduralTextureGenerator.cpp
@@ -94,8 +94,8 @@ TextureBufferPtr Cell::process()
 	{
 		for (size_t x = 0; x < mDensity; ++x)
 		{
-			Ogre::Real rand1 = (Ogre::Real)rand() / 65536.0f;
-			Ogre::Real rand2 = (Ogre::Real)rand() / 65536.0f;
+			Ogre::Real rand1 = 0.5*(Ogre::Real)rand() / RAND_MAX;
+			Ogre::Real rand2 = 0.5*(Ogre::Real)rand() / RAND_MAX;
 			cellPoints[x + y * mDensity].x = (x + 0.5f + (rand1 - 0.5f) * (1 - regularity)) / mDensity - 1.f / mBuffer->getWidth();
 			cellPoints[x + y * mDensity].y = (y + 0.5f + (rand2 - 0.5f) * (1 - regularity)) / mDensity - 1.f / mBuffer->getHeight();
 			cellPoints[x + y * mDensity].z = 0;

--- a/library/src/ProceduralTriangleBuffer.cpp
+++ b/library/src/ProceduralTriangleBuffer.cpp
@@ -36,11 +36,12 @@ using namespace Ogre;
 namespace Procedural
 {
 Ogre::v1::MeshPtr TriangleBuffer::transformToMesh(const std::string& name,
-        const Ogre::String& group) const
+        const Ogre::String& group,
+        const Ogre::String& materialName) const
 {
 	Ogre::SceneManager* sceneMgr = Ogre::Root::getSingleton().getSceneManagerIterator().begin()->second;
 	Ogre::v1::ManualObject* manual = OGRE_NEW Ogre::v1::ManualObject(Ogre::Id::generateNewId<Ogre::v1::ManualObject>(), &sceneMgr->_getEntityMemoryManager(Ogre::SCENE_DYNAMIC), sceneMgr);
-	manual->begin("BaseWhiteNoLighting", Ogre::OperationType::OT_TRIANGLE_LIST);
+	manual->begin(materialName, Ogre::OperationType::OT_TRIANGLE_LIST);
 
 #if OGRE_VERSION >= ((2 << 16) | (0 << 8) | 0)
 	Ogre::Vector3 aabb_min = Ogre::Vector3::ZERO;

--- a/samples/material/src/Material.cpp
+++ b/samples/material/src/Material.cpp
@@ -102,7 +102,6 @@ void Sample_Material::createScene(void)
 	if (Ogre::RTShader::ShaderGenerator::initialize())
 	{
 		Ogre::RTShader::ShaderGenerator* mShaderGenerator = Ogre::RTShader::ShaderGenerator::getSingletonPtr();
-		mShaderGenerator->setShaderCachePath(".");
 		RTShader::RenderState* pMainRenderState = mShaderGenerator->createOrRetrieveRenderState(RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME).first;
 		pMainRenderState->reset();
 
@@ -113,6 +112,7 @@ void Sample_Material::createScene(void)
 
 		pMainRenderState->addTemplateSubRenderState(normalMapSubRS);
 		mShaderGenerator->createShaderBasedTechnique(*demoMaterial, Ogre::MaterialManager::DEFAULT_SCHEME_NAME, Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME);
+		mCam->getViewport()->setMaterialScheme(Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME);
 	}
 
 	// -- Test plane


### PR DESCRIPTION
As the title says, add support to choose meshes material during the invocation of `realizeMesh` and `transformToMesh` methods.
Indeed, there's no way of doing it and the material name is hardcoded to `BaseWhiteNoLighting`. The PR doesn't break the API since the material name is specified as a default parameter.

With very little changes, the PR should be also applicable to master branch too.