### PR TITLE
Fix arithmetic on a pointer to an incomplete type 'const Procedural::Shape'

### DIFF
--- a/library/include/ProceduralMultiShape.h
+++ b/library/include/ProceduralMultiShape.h
@@ -96,13 +96,7 @@ public:
 	}
 
 	/// Append every shape of an other multishape to the current multiShape
-	void addMultiShape(const MultiShape& other)
-	{
-		for (std::vector<Shape>::const_iterator it = other.mShapes.begin(); it!=other.mShapes.end(); ++it)
-		{
-			mShapes.push_back(*it);
-		}
-	}
+	void addMultiShape(const MultiShape& other);
 
 	/// Outputs the Multi Shape to a Mesh, mostly for visualisation or debugging purposes
 	Ogre::MeshPtr realizeMesh(const std::string& name="");

--- a/library/src/ProceduralMultiShape.cpp
+++ b/library/src/ProceduralMultiShape.cpp
@@ -82,6 +82,15 @@ std::vector<Vector2> MultiShape::getPoints() const
 }
 //-----------------------------------------------------------------------
 
+void MultiShape::addMultiShape(const MultiShape& other)
+{
+	for (std::vector<Shape>::const_iterator it = other.mShapes.begin(); it!=other.mShapes.end(); ++it)
+	{
+		mShapes.push_back(*it);
+	}
+}
+//-----------------------------------------------------------------------
+
 bool MultiShape::isPointInside(const Vector2& point) const
 {
 	// Draw a horizontal lines that goes through "point"


### PR DESCRIPTION
When building in macOS using Xcode, it was throwing the error:
`Fix arithmetic on a pointer to an incomplete type 'const Procedural::Shape'
`

This pull request moves the implementation of the addMultiShape method to the CPP to avoid the use of incomplete type.

![image](https://user-images.githubusercontent.com/996529/213068174-a4860e1a-bc68-45f0-a5a7-54a309f264a8.png)