### PR TITLE
Fix static build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,17 @@ if (IS_DIRECTORY "${OgreProcedural_SOURCE_DIR}/Dependencies")
 endif()
 
 find_package(OGRE REQUIRED CONFIG)
+if (OGRE_STATIC)
+find_package(ZLIB)
+find_package(SDL2)
+find_package(assimp CONFIG)
+
+add_library(fix::assimp INTERFACE IMPORTED)
+set_target_properties(fix::assimp PROPERTIES
+	INTERFACE_LINK_LIBRARIES "${ASSIMP_LIBRARIES};pugixml"
+	INTERFACE_LINK_DIRECTORIES "${ASSIMP_LIBRARY_DIRS}"
+)
+endif()
 link_directories(${OGRE_LIBRARY_DIRS})
 
 # Unity build options


### PR DESCRIPTION
Without the change I see static build as broken. Somehow x86_64 build hides the problem but it shows on aarch64 build quite reliably. Probably due to a bit slower target or number of cores play the role... Dunno, but now it is fine.
